### PR TITLE
sorting for unknown layers fix to ensure stable sorting order

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,8 +161,12 @@ const fallbacks = [
   { either: isSmallLocality, resolve: resolveSmallLocality },
   { either: isSmallLocaladmin, resolve: resolveSmallLocaladmin },
   { either: isNonPopularNeighbourhood, resolve: resolveNonPopularNeighbourhood },
-  // the 'else' case, always returns true
-  { either: _.constant(true), resolve: (result1, result2) => { return result1 < result2; } }
+  // the 'else' case, always sort by score, avoiding returning 0 because js sort is unstable
+  { either: _.constant(true), resolve: (result1, result2) => {
+    if( isNaN( result1._score ) || isNaN( result2._score ) ){ return -1; }
+    if( result1._score === result2._score ){ return -1; }
+    return result1._score > result2._score ? -1 : 1;
+  }}
 ];
 
 module.exports = (clean) => {

--- a/test/index.js
+++ b/test/index.js
@@ -342,4 +342,21 @@ tape('neighbourhood', (test) => {
 
   });
 
+  test.test('custom layers should be sorted by score', t => {
+    const sorter = require('../index')({});
+
+    const result_one = new ResultBuilder('stops').score(27.178297).build();
+    const result_two = new ResultBuilder('stops').score(1.4754213).build();
+    const result_three = new ResultBuilder('stops').score(1.4754213).build();
+
+    t.equals(sorter(result_one, result_two), -1);
+    t.equals(sorter(result_two, result_one), +1);
+    t.equals(sorter(result_two, result_three), -1);
+    t.equals(sorter(result_three, result_two), -1);
+    t.equals(sorter(result_one, result_three), -1);
+    t.equals(sorter(result_three, result_one), +1);
+    t.end();
+
+  });
+
 });


### PR DESCRIPTION
Today I was investigating the following query:

```
/v1/search?text=stop 2

 1)	SW Terwilliger & 2nd (TriMet Stop ID 5813), Portland, OR, USA
 2)	A Ave & Chandler (TriMet Stop ID 2), Lake Oswego, OR, USA
 3)	NE Broadway & 2nd (TriMet Stop ID 633), Portland, OR, USA
 4)	SW Hall & 2nd (TriMet Stop ID 2302), Beaverton, OR, USA
 5)	SE Kane & 2nd (TriMet Stop ID 3101), Gresham, OR, USA
 6)	SW Pine & 2nd (TriMet
... etc
```

It turned out that elasticsearch was returning `TriMet Stop ID 2` but this module was re-sorting the results to put `TriMet Stop ID 5813` higher.

In this PR is a fix to ensure that the sorting is corrected:

```
/v1/search?text=stop 2

 1)	A Ave & Chandler (TriMet Stop ID 2), Lake Oswego, OR, USA
 2)	N Main & NE 2nd (TriMet Stop ID 3715), Gresham, OR, USA
 3)	SW Taylors Ferry & Riverview (2nd) (TriMet Stop ID 5705), Portland, OR, USA
 4)	SW Taylors Ferry & 2nd (TriMet Stop ID 5717), Portland, OR, USA
 5)	SW Taylors Ferry & 2nd (TriMet Stop ID 5718), Portland, OR, USA
```

Note: this only applies when the sorting algorithm is comparing two unknown layers.

The previous code had code which returned `{ return result1 < result2; }` which are objects, so I'm not sure the intent there, the comment above says `// the 'else' case, always returns true`.

@trescube do you remember why this might have been the way it was?

I've also taken some care not to return `0` as javascript has a nonstable sorting function, so I'm returning `-1` instead of 0 to ensure that the leftmost element stays to the left.