### PR TITLE
Drop support for Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 notifications:
   email: false
 node_js:
-  - 8
   - 10
   - 12
 script: npm run travis

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Pelias",
   "license": "MIT",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node.js 8 is no longer supported as it reached [end of life](https://github.com/nodejs/Release#release-schedule) at the end of 2019.

Connects https://github.com/pelias/pelias/issues/837